### PR TITLE
Avoiding ReferenceError: cosMap is not defined

### DIFF
--- a/src/dct.js
+++ b/src/dct.js
@@ -7,7 +7,7 @@
  * tool to understand the Mel-scale and its related coefficients used in
  * human speech analysis.
 \*===========================================================================*/
-cosMap = null;
+var cosMap = null;
 
 // Builds a cosine map for the given input size. This allows multiple input sizes to be memoized automagically
 // if you want to run the DCT over and over.


### PR DESCRIPTION
declaring `cosMap` using `var` to avoid ReferenceError: cosMap is not defined